### PR TITLE
Guarantee invertibility of constants_matrix, plus readability improvements

### DIFF
--- a/instance_generator.sage
+++ b/instance_generator.sage
@@ -343,7 +343,7 @@ class Rescue:
         chunk_size = ceil(log(1.0*F.order(),2.0) / 8 ) + 1
         while len(constants) != 2*m + m^2:
             have_constant = False
-            while have_constant == False:
+            while not have_constant:
                 if counter+chunk_size > len(randomness):
                     raise BufferError
                 constant = Rescue.field_element_from_bytes(F, randomness[counter:(counter+chunk_size)])
@@ -353,7 +353,7 @@ class Rescue:
                 # subfields do we accept it
                 if Rescue.is_generator(F, constant):
                     constants.append(constant)
-                    break
+                    have_constant = True
 
             # if the m^2 first constants do not
             # define an invertible matrix, reject them

--- a/instance_generator.sage
+++ b/instance_generator.sage
@@ -328,8 +328,8 @@ class Rescue:
             except BufferError:
                 continue
 
-        initial_constant = matrix([[constants[i]] for i in range(0, m)])
-        constants_matrix = matrix([[constants[m+i*m+j] for j in range(0,m)] for i in range(0,m)])
+        constants_matrix = matrix([[constants[i*m+j] for j in range(0,m)] for i in range(0,m)])
+        initial_constant = matrix([[constants[m+i]] for i in range(0, m)])
         constants_constant = matrix([[constants[m+m^2+i]] for i in range(0,m)])
         return initial_constant, constants_matrix, constants_constant
 

--- a/instance_generator.sage
+++ b/instance_generator.sage
@@ -279,12 +279,7 @@ class Rescue:
         Fpx.<x> = PolynomialRing(Fp, "x")
 
         integer = 1
-        expansion = []
-        int_cpy = copy(integer)
-        while int_cpy > 0:
-            expansion.append(int_cpy % p)
-            int_cpy = int_cpy // p
-        poly = Fp(1) * x^d + sum(Fp(expansion[i]) * x^i for i in range(0, len(expansion)))
+        poly = Fp(1) * x^d + Fp(1)
         while not poly.is_irreducible():
             integer += 1
             int_cpy = copy(integer)


### PR DESCRIPTION
Method `sample_constants` checks the _first_ m² random values for invertability (when written as a m⨉m matrix). Thus, when using the return value of `sample_constants` in `sample_parameters`, the same first m² entries should be used to construct the matrix.

Bonus:
- 71eddee: Remove duplicate code always evaluating to x^d + 1
- bc0b046: Make use of almost-pre-existing check instead of break for better readability